### PR TITLE
Fixed behavior on ensure = absent

### DIFF
--- a/manifests/definitions/lookupkey.pp
+++ b/manifests/definitions/lookupkey.pp
@@ -16,7 +16,6 @@ define users::lookupkey($ensure = present) {
         type    => "$type",
         user    => "$name",
         options => $options,
-        target  => "/home/${name}/.ssh/authorized_keys",
         require => [ User["$name"], File["/home/${name}/.ssh"], ],
     }
 }

--- a/manifests/definitions/useraccount.pp
+++ b/manifests/definitions/useraccount.pp
@@ -58,8 +58,6 @@ define users::useraccount ( $ensure = present, $fullname, $uid = '', $groups = [
         }
     }
 
-    case $ensure {
-        present: {
             if versioncmp($puppetversion, '0.25') >= 0 {
                 $managedDirs = [
                     "/etc/puppet/files/users/home/managed/host/${username}.$fqdn",
@@ -150,8 +148,6 @@ define users::useraccount ( $ensure = present, $fullname, $uid = '', $groups = [
                 require => File["/home/${username}"],
             }
         }
-    }
-}
 
 # vim modeline - have 'set modeline' and 'syntax on' in your ~/.vimrc.
 # vi:syntax=puppet:filetype=puppet:ts=4:et:

--- a/manifests/definitions/useraccount.pp
+++ b/manifests/definitions/useraccount.pp
@@ -58,96 +58,96 @@ define users::useraccount ( $ensure = present, $fullname, $uid = '', $groups = [
         }
     }
 
-            if versioncmp($puppetversion, '0.25') >= 0 {
-                $managedDirs = [
-                    "/etc/puppet/files/users/home/managed/host/${username}.$fqdn",
-                    "/etc/puppet/files/users/home/managed/host/${username}.$hostname",
-                    "/etc/puppet/files/users/home/managed/domain/${username}.$domain",
-                    "/etc/puppet/files/users/home/managed/env/${username}.$environment",
-                    "/etc/puppet/files/users/home/managed/user/${username}",
-                    "/etc/puppet/files/users/home/managed/skel",
-                ]
+    if versioncmp($puppetversion, '0.25') >= 0 {
+      $managedDirs = [
+      "/etc/puppet/files/users/home/managed/host/${username}.$fqdn",
+      "/etc/puppet/files/users/home/managed/host/${username}.$hostname",
+      "/etc/puppet/files/users/home/managed/domain/${username}.$domain",
+      "/etc/puppet/files/users/home/managed/env/${username}.$environment",
+      "/etc/puppet/files/users/home/managed/user/${username}",
+      "/etc/puppet/files/users/home/managed/skel",
+      ]
 
-                case generate('/etc/puppet/modules/users/scripts/findDirs.sh', $managedDirs) {
-                    '': {
-                        file { "/home/${username}":
-                            ensure       => $ensure ? {
-                                present => directory,
-                                absent  => absent,
-                            },
-                            owner        => $home_owner,
-                            group        => $home_group,
-                            #mode        => 644,    # Cannot apply mode, or it will change ALL files
-                            recurse      => remote,
-                            replace      => false,
-                            ignore       => [ '*.git', '*.swp', '*.un~' ],
-                            source       => [
-                                "puppet:///files/users/home/default/host/${username}.$fqdn",
-                                "puppet:///files/users/home/default/host/${username}.$hostname",
-                                "puppet:///files/users/home/default/domain/${username}.$domain",
-                                "puppet:///files/users/home/default/env/${username}.$environment",
-                                "puppet:///files/users/home/default/user/${username}",
-                                "puppet:///files/users/home/default/skel",
-                                "puppet:///users/home/default",
-                            ],
-                            sourceselect => all,
-                            require      => User["${username}"],
-                        }
-                    }
-                    default: {
-                        file { "/home/${username}":
-                            ensure       => $ensure ? {
-                                present => directory,
-                                absent  => absent,
-                            },
-                            owner        => $home_owner,
-                            group        => $home_group,
-                            #mode        => 644, # Cannot apply mode, or it will change ALL files
-                            recurse      => remote,
-                            replace      => true,
-                            force        => true,
-                            ignore       => '.git',
-                            source       => [
-                                "puppet:///files/users/home/managed/host/${username}.$fqdn",
-                                "puppet:///files/users/home/managed/host/${username}.$hostname",
-                                "puppet:///files/users/home/managed/domain/${username}.$domain",
-                                "puppet:///files/users/home/managed/env/${username}.$environment",
-                                "puppet:///files/users/home/managed/user/${username}",
-                                "puppet:///files/users/home/managed/skel",
-                            ],
-                            sourceselect => all,
-                            require      => User["${username}"],
-                        }
-                    }
-                }
-            } else {
-                file { "/home/${username}":
-                    ensure  => $ensure ? {
-                        present => directory,
-                        absent  => absent,
-                    },
-                    owner   => $home_owner,
-                    group   => $home_group,
-                    mode    => 644, # Cannot apply mode, or it will change ALL files
-                    require   => User["${username}"],
-                }
-            }
-
-            file { "/home/${username}/.bash_history":
-                mode => 600,
-                owner   => $home_owner,
-                group   => $home_group,
-                require => File["/home/${username}"],
-            }
-
-            file { "/home/${username}/.ssh":
-                ensure  => directory,
-                owner   => $home_owner,
-                group   => $home_group,
-                mode    => 700,
-                require => File["/home/${username}"],
-            }
+      case generate('/etc/puppet/modules/users/scripts/findDirs.sh', $managedDirs) {
+        '': {
+          file { "/home/${username}":
+          ensure       => $ensure ? {
+            present => directory,
+            absent  => absent,
+            },
+            owner        => $home_owner,
+            group        => $home_group,
+            #mode        => 644,    # Cannot apply mode, or it will change ALL files
+            recurse      => remote,
+            replace      => false,
+            ignore       => [ '*.git', '*.swp', '*.un~' ],
+            source       => [
+            "puppet:///files/users/home/default/host/${username}.$fqdn",
+            "puppet:///files/users/home/default/host/${username}.$hostname",
+            "puppet:///files/users/home/default/domain/${username}.$domain",
+            "puppet:///files/users/home/default/env/${username}.$environment",
+            "puppet:///files/users/home/default/user/${username}",
+            "puppet:///files/users/home/default/skel",
+            "puppet:///users/home/default",
+            ],
+            sourceselect => all,
+            require      => User["${username}"],
+          }
         }
+        default: {
+          file { "/home/${username}":
+          ensure       => $ensure ? {
+            present => directory,
+            absent  => absent,
+            },
+            owner        => $home_owner,
+            group        => $home_group,
+            #mode        => 644, # Cannot apply mode, or it will change ALL files
+            recurse      => remote,
+            replace      => true,
+            force        => true,
+            ignore       => '.git',
+            source       => [
+            "puppet:///files/users/home/managed/host/${username}.$fqdn",
+            "puppet:///files/users/home/managed/host/${username}.$hostname",
+            "puppet:///files/users/home/managed/domain/${username}.$domain",
+            "puppet:///files/users/home/managed/env/${username}.$environment",
+            "puppet:///files/users/home/managed/user/${username}",
+            "puppet:///files/users/home/managed/skel",
+            ],
+            sourceselect => all,
+            require      => User["${username}"],
+          }
+        }
+      }
+      } else {
+        file { "/home/${username}":
+        ensure  => $ensure ? {
+          present => directory,
+          absent  => absent,
+          },
+          owner   => $home_owner,
+          group   => $home_group,
+          mode    => 644, # Cannot apply mode, or it will change ALL files
+          require   => User["${username}"],
+        }
+      }
+
+      file { "/home/${username}/.bash_history":
+      mode => 600,
+      owner   => $home_owner,
+      group   => $home_group,
+      require => File["/home/${username}"],
+    }
+
+    file { "/home/${username}/.ssh":
+    ensure  => directory,
+    owner   => $home_owner,
+    group   => $home_group,
+    mode    => 700,
+    require => File["/home/${username}"],
+  }
+}
 
 # vim modeline - have 'set modeline' and 'syntax on' in your ~/.vimrc.
 # vi:syntax=puppet:filetype=puppet:ts=4:et:

--- a/manifests/definitions/useraccount.pp
+++ b/manifests/definitions/useraccount.pp
@@ -71,9 +71,9 @@ define users::useraccount ( $ensure = present, $fullname, $uid = '', $groups = [
       case generate('/etc/puppet/modules/users/scripts/findDirs.sh', $managedDirs) {
         '': {
           file { "/home/${username}":
-          ensure       => $ensure ? {
-            present => directory,
-            absent  => absent,
+            ensure       => $ensure ? {
+              present => directory,
+              absent  => absent,
             },
             owner        => $home_owner,
             group        => $home_group,
@@ -96,18 +96,18 @@ define users::useraccount ( $ensure = present, $fullname, $uid = '', $groups = [
         }
         default: {
           file { "/home/${username}":
-          ensure       => $ensure ? {
-            present => directory,
-            absent  => absent,
+            ensure        => $ensure ? {
+              present => directory,
+              absent  => absent,
             },
-            owner        => $home_owner,
-            group        => $home_group,
-            #mode        => 644, # Cannot apply mode, or it will change ALL files
-            recurse      => remote,
-            replace      => true,
-            force        => true,
-            ignore       => '.git',
-            source       => [
+            owner         => $home_owner,
+            group         => $home_group,
+            #mode         => 644, # Cannot apply mode, or it will change ALL files
+            recurse       => remote,
+            replace       => true,
+            force         => true,
+            ignore        => '.git',
+            source        => [
             "puppet:///files/users/home/managed/host/${username}.$fqdn",
             "puppet:///files/users/home/managed/host/${username}.$hostname",
             "puppet:///files/users/home/managed/domain/${username}.$domain",
@@ -115,38 +115,38 @@ define users::useraccount ( $ensure = present, $fullname, $uid = '', $groups = [
             "puppet:///files/users/home/managed/user/${username}",
             "puppet:///files/users/home/managed/skel",
             ],
-            sourceselect => all,
-            require      => User["${username}"],
+            sourceselect  => all,
+            require       => User["${username}"],
           }
         }
       }
       } else {
         file { "/home/${username}":
-        ensure  => $ensure ? {
-          present => directory,
-          absent  => absent,
+          ensure  => $ensure ? {
+            present => directory,
+            absent  => absent,
           },
           owner   => $home_owner,
           group   => $home_group,
           mode    => 644, # Cannot apply mode, or it will change ALL files
-          require   => User["${username}"],
+          require => User["${username}"],
         }
       }
 
       file { "/home/${username}/.bash_history":
-      mode => 600,
-      owner   => $home_owner,
-      group   => $home_group,
-      require => File["/home/${username}"],
-    }
+        mode => 600,
+        owner   => $home_owner,
+        group   => $home_group,
+        require => File["/home/${username}"],
+      }
 
-    file { "/home/${username}/.ssh":
-    ensure  => directory,
-    owner   => $home_owner,
-    group   => $home_group,
-    mode    => 700,
-    require => File["/home/${username}"],
-  }
+      file { "/home/${username}/.ssh":
+        ensure  => directory,
+        owner   => $home_owner,
+        group   => $home_group,
+        mode    => 700,
+        require => File["/home/${username}"],
+      }
 }
 
 # vim modeline - have 'set modeline' and 'syntax on' in your ~/.vimrc.


### PR DESCRIPTION
I removed the selector in useraccount.pp as all resources already handle $ensure properly.

Also, the ssh_authorized_key resource in lookupkey.pp doesn't need the target property as it defaults to ~user/.ssh/authorized_keys. Puppet somehow got stuck on this trying to resolve the uid of the already removed user.
